### PR TITLE
Don't fail if memfd_create() is not available

### DIFF
--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -12,9 +12,11 @@
 #include "fwupd-release.h"
 
 #ifdef HAVE_GIO_UNIX
+#include <glib/gstdio.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <sys/mman.h>
+#include <unistd.h>
 #endif
 
 #include <locale.h>
@@ -1055,11 +1057,30 @@ fwupd_input_stream_read_bytes_finish (GInputStream *stream,
 GUnixInputStream *
 fwupd_unix_input_stream_from_bytes (GBytes *bytes, GError **error)
 {
-#ifdef HAVE_MEMFD_CREATE
 	gint fd;
 	gssize rc;
+#ifndef HAVE_MEMFD_CREATE
+	gchar tmp_file[] = "/tmp/fwupd.XXXXXX";
+#endif
 
+#ifdef HAVE_MEMFD_CREATE
 	fd = memfd_create ("fwupd", MFD_CLOEXEC);
+#else
+	/* emulate in-memory file by an unlinked temporary file */
+	fd = g_mkstemp (tmp_file);
+	if (fd != -1) {
+		rc = g_unlink (tmp_file);
+		if (rc != 0) {
+			(void) close (fd);
+			g_set_error_literal (error,
+					     FWUPD_ERROR,
+					     FWUPD_ERROR_INVALID_FILE,
+					     "failed to unlink temporary file");
+			return NULL;
+		}
+	}
+#endif
+
 	if (fd < 0) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
@@ -1083,13 +1104,6 @@ fwupd_unix_input_stream_from_bytes (GBytes *bytes, GError **error)
 		return NULL;
 	}
 	return G_UNIX_INPUT_STREAM (g_unix_input_stream_new (fd, TRUE));
-#else
-	g_set_error_literal (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_INTERNAL,
-			     "memfd_create() not available");
-	return NULL;
-#endif
 }
 
 /**


### PR DESCRIPTION
Uses Glib's File IO functions to make a temporary file that's gone with the last descriptor to it.